### PR TITLE
[Feat] add date to trailing widget in journal listing

### DIFF
--- a/lib/widgets/journal_list.dart
+++ b/lib/widgets/journal_list.dart
@@ -138,30 +138,16 @@ class _JournalListState extends State<JournalList> {
 
   Widget _buildRow(BuildContext context, Note note) {
     var textTheme = Theme.of(context).textTheme;
-    var title = note.title;
+
+    var title = note.title ?? note.fileName;
     Widget titleWidget = Text(title, style: textTheme.title);
-    if (title.isEmpty) {
-      var date = note.modified ?? note.created;
-      if (date != null) {
-        var formatter = DateFormat('dd MMM, yyyy  ');
-        var dateStr = formatter.format(date);
+    Widget trailing;
 
-        var timeFormatter = DateFormat('Hm');
-        var time = timeFormatter.format(date);
-
-        var timeColor = textTheme.body1.color.withAlpha(100);
-
-        titleWidget = Row(
-          children: <Widget>[
-            Text(dateStr, style: textTheme.title),
-            Text(time, style: textTheme.body1.copyWith(color: timeColor)),
-          ],
-          crossAxisAlignment: CrossAxisAlignment.baseline,
-          textBaseline: TextBaseline.alphabetic,
-        );
-      } else {
-        titleWidget = Text(note.fileName, style: textTheme.title);
-      }
+    var date = note.modified ?? note.created;
+    if (date != null) {
+      var formatter = DateFormat('dd MMM, yyyy');
+      var dateStr = formatter.format(date);
+      trailing = Text(dateStr, style: textTheme.caption);
     }
 
     var body = stripMarkdownFormatting(note.body);
@@ -179,6 +165,7 @@ class _JournalListState extends State<JournalList> {
     var tile = ListTile(
       isThreeLine: true,
       title: titleWidget,
+      trailing: trailing,
       subtitle: Column(
         children: children,
         crossAxisAlignment: CrossAxisAlignment.start,


### PR DESCRIPTION
Add widget to show last modification or creation date if available.
Also change default title to file instead of date, because we have date on trailing.
![image](https://user-images.githubusercontent.com/2872741/73950814-9fa4c680-490d-11ea-9fcc-184b7661e0a5.png)
