### PR TITLE
fix twitter link

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Features -
 - **[Discord Server](https://discord.gg/abBwyEK)**
 - **Reddit Community** - [Join Us](https://www.reddit.com/r/GitJournal/)
 - **Newsletter** - [Signup Here](https://gitjournal.io/newsletter)
-- **Twitter** - [Follow for Updates](https://twitter.com/GitJournal_io)
+- **Twitter** - [Follow for Updates](https://twitter.com/GitJournalApp)
 
 # Screenshots
 


### PR DESCRIPTION
## Connection with issue(s)

No issues related. I've just noticed the twitter link were leading to an nonexistent account.

<!-- Required: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request -->

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->

## Testing and Review Notes

Click in the new link and it will lead you to <https://twitter.com/GitJournalApp>

## Screenshots or Videos

![image](https://user-images.githubusercontent.com/8508804/101340333-563f4380-385e-11eb-8b53-153a7544c39e.png)

