### PR TITLE
Fix dependency package changes

### DIFF
--- a/lib/widgets/note_editor_selector.dart
+++ b/lib/widgets/note_editor_selector.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 
 import 'package:easy_localization/easy_localization.dart';
-import 'package:font_awesome_flutter/fa_icon.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 import 'package:gitjournal/core/note.dart';

--- a/lib/widgets/sync_button.dart
+++ b/lib/widgets/sync_button.dart
@@ -187,7 +187,7 @@ class GitPendingChangesBadge extends StatelessWidget {
       badgeContent: Text(repo.numChanges.toString(), style: style),
       showBadge: repo.numChanges != 0,
       badgeColor: theme.iconTheme.color,
-      position: BadgePosition.topRight(top: 10.0, right: 4.0),
+      position: BadgePosition.topEnd(top: 10.0, end: 4.0),
       child: child,
     );
   }


### PR DESCRIPTION
package:
in font_awesome_flutter version is 8.11.0
in badges 1.1.6

* /Users/huangzheng/GitJournal/lib/widgets/sync_button.dart (git)
```dart
// position: BadgePosition.topRight(top: 10.0, right: 4.0),
position: BadgePosition.topEnd(top: 10.0, end: 4.0),
```
> https://github.com/yako-dev/flutter_badges/commit/11cca1a24beb8aa9045d60b5e7ade40c57f9b427#diff-af795eb386328cb61b36d6af1549d87a6b0e2fafaf55ee2ce0ae7d7505e364dd

* /Users/huangzheng/GitJournal/lib/widgets/note_editor_selector.dart (git)

```dart
import 'package:font_awesome_flutter/fa_icon.dart';
// import 'package:font_awesome_flutter/fa_icon.dart';
```
* lint error 
> Target of URI doesn't exist: 'package:font_awesome_flutter/fa_icon.dart'.
> Try creating the file referenced by the URI, or Try using a URI for a file that does exist.
