### PR TITLE
using a correct gradle version

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -37,9 +37,10 @@ classpath 'com.android.tools.build:gradle:3.3.2'
 ```
 to
 ```gradle
-classpath 'com.android.tools.build:gradle:3.5.0'
+classpath 'com.android.tools.build:gradle:3.5.4'
 ```
 fixes your issue.
+
 ## IDE Setup
 
 VS Code has great plugin for flutter, but you need to add args to launch.json.


### PR DESCRIPTION
Adjusting the instructions to recommend Gradle 3.5.4 instead of 3.5.0.
3.5.0 seems to have an issue, described in https://github.com/GitJournal/GitJournal/issues/440#issuecomment-791253320

## Connection with issue(s)

Connected to #440

## Testing and Review Notes

Just a doc adjustment.

