### PR TITLE
persisting the 'include subfolders' setting

### DIFF
--- a/lib/app_settings.dart
+++ b/lib/app_settings.dart
@@ -109,6 +109,8 @@ class AppSettings extends ChangeNotifier {
         pref, "validateProMode", validateProMode, defaultSet.validateProMode);
     _setString(pref, "debugLogLevel", debugLogLevel, defaultSet.debugLogLevel);
     _setBool(pref, "experimentalFs", experimentalFs, defaultSet.experimentalFs);
+    _setBool(pref, "experimentalSubfolders", experimentalSubfolders,
+        defaultSet.experimentalSubfolders);
     _setBool(pref, "experimentalMarkdownToolbar", experimentalMarkdownToolbar,
         defaultSet.experimentalMarkdownToolbar);
     _setBool(pref, "experimentalGraphView", experimentalGraphView,

--- a/lib/app_settings.dart
+++ b/lib/app_settings.dart
@@ -77,6 +77,8 @@ class AppSettings extends ChangeNotifier {
 
     debugLogLevel = pref.getString("debugLogLevel") ?? debugLogLevel;
     experimentalFs = pref.getBool("experimentalFs") ?? experimentalFs;
+    experimentalSubfolders =
+        pref.getBool("experimentalSubfolders") ?? experimentalSubfolders;
     experimentalMarkdownToolbar = pref.getBool("experimentalMarkdownToolbar") ??
         experimentalMarkdownToolbar;
     experimentalGraphView =


### PR DESCRIPTION
I noticed that the setting for "include folders" is getting reset at times. Now I see that it does not get loaded. This should fix it.