### PR TITLE
add "keywords" alias for tags to be compatible with pandoc and zettlr

### DIFF
--- a/lib/core/note_serializer.dart
+++ b/lib/core/note_serializer.dart
@@ -212,6 +212,7 @@ class NoteSerializer implements NoteSerializerInterface {
       var tagKeyOptions = [
         "tags",
         "categories",
+        "keywords",
       ];
       for (var possibleKey in tagKeyOptions) {
         var tags = data.props[possibleKey];

--- a/lib/screens/settings_note_metadata.dart
+++ b/lib/screens/settings_note_metadata.dart
@@ -145,6 +145,7 @@ class _NoteMetadataSettingsScreenState
           options: [
             "tags",
             "categories",
+            "keywords",
           ],
           currentOption: settings.yamlTagsKey,
           onChange: (String newVal) {


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue #491 

## Testing and Review Notes

Make sure, generated notes save their tags under the "keywords" key.


## To Do

- [X] double check the original issue to confirm it is fully satisfied
- [X] add testing notes and screenshots in PR description to help guide reviewers
