### PR TITLE
enhancement: Adding treatment of HardWraps.

### DIFF
--- a/assets/langs/en.yaml
+++ b/assets/langs/en.yaml
@@ -194,6 +194,7 @@ settings:
     swipe: Swipe to Delete Note
     listView: List View
     confirmDelete: Show a Popup to Confirm Deletes
+    hardWrap: Enable hardWrap
   NoteFileNameFormat:
     iso8601WithTimeZone: ISO8601 With TimeZone
     iso8601: ISO8601

--- a/assets/langs/ja.yaml
+++ b/assets/langs/ja.yaml
@@ -194,6 +194,7 @@ settings:
     swipe: スワイプでノートを削除する
     listView: リストビュー
     confirmDelete: 削除時に確認をポップアップする
+    hardWrap: hardWrapを有効にする
   NoteFileNameFormat:
     iso8601WithTimeZone: タイムゾーン付きISO8601形式
     iso8601: ISO8601形式

--- a/lib/core/hardwrap.dart
+++ b/lib/core/hardwrap.dart
@@ -1,0 +1,13 @@
+import 'package:markdown/markdown.dart' as md;
+
+/// Represents a hard line break.
+class HardWrapSyntax extends md.InlineSyntax {
+  HardWrapSyntax() : super(r'\n');
+
+  /// Create a void <br> element.
+  @override
+  bool onMatch(md.InlineParser parser, Match match) {
+    parser.addNode(md.Element.empty('br'));
+    return true;
+  }
+}

--- a/lib/core/hardwrap.dart
+++ b/lib/core/hardwrap.dart
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2021 Vishesh Handa <me@vhanda.in>
+Copyright 2020-2021 vorotamoroz <vrtmrz@gmail.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/core/hardwrap.dart
+++ b/lib/core/hardwrap.dart
@@ -1,3 +1,19 @@
+/*
+Copyright 2020-2021 Vishesh Handa <me@vhanda.in>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import 'package:markdown/markdown.dart' as md;
 
 /// Represents a hard line break.

--- a/lib/settings/settings.dart
+++ b/lib/settings/settings.dart
@@ -112,6 +112,7 @@ class Settings extends ChangeNotifier {
 
   bool bottomMenuBar = true;
   bool confirmDelete = true;
+  bool hardWrap = false;
 
   bool storeInternally = true;
   String storageLocation = "";
@@ -231,6 +232,8 @@ class Settings extends ChangeNotifier {
     confirmDelete = _getBool(pref, "confirmDelete") ?? confirmDelete;
     storeInternally = _getBool(pref, "storeInternally") ?? storeInternally;
     storageLocation = _getString(pref, "storageLocation") ?? "";
+
+    hardWrap = _getBool(pref, "hardWrap") ?? hardWrap;
   }
 
   String? _getString(SharedPreferences pref, String key) {
@@ -400,6 +403,8 @@ class Settings extends ChangeNotifier {
     await _setInt(pref, "settingsVersion", version, defaultSet.version);
 
     await _setString(pref, FOLDER_NAME_KEY, folderName, defaultSet.folderName);
+
+    await _setBool(pref, "hardWrap", hardWrap, defaultSet.hardWrap);
 
     notifyListeners();
   }

--- a/lib/settings/settings_misc.dart
+++ b/lib/settings/settings_misc.dart
@@ -51,6 +51,14 @@ class _SettingsMiscState extends State<SettingsMisc> {
             settings.save();
           },
         ),
+        SwitchListTile(
+          title: Text(tr('settings.misc.hardWrap')),
+          value: settings.hardWrap,
+          onChanged: (bool newVal) {
+            settings.hardWrap = newVal;
+            settings.save();
+          },
+        ),
       ],
       crossAxisAlignment: CrossAxisAlignment.start,
     );

--- a/lib/settings/settings_misc.dart
+++ b/lib/settings/settings_misc.dart
@@ -1,3 +1,19 @@
+/*
+Copyright 2020-2021 Vishesh Handa <me@vhanda.in>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import 'package:flutter/material.dart';
 
 import 'package:easy_localization/easy_localization.dart';

--- a/lib/widgets/markdown_renderer.dart
+++ b/lib/widgets/markdown_renderer.dart
@@ -23,10 +23,13 @@ import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:function_types/function_types.dart';
 import 'package:markdown/markdown.dart' as md;
 import 'package:path/path.dart' as p;
+import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'package:gitjournal/core/link.dart';
 import 'package:gitjournal/core/note.dart';
+import 'package:gitjournal/core/hardwrap.dart';
+import 'package:gitjournal/settings/settings.dart';
 import 'package:gitjournal/folder_views/common.dart';
 import 'package:gitjournal/utils/link_resolver.dart';
 import 'package:gitjournal/utils/logger.dart';
@@ -46,6 +49,7 @@ class MarkdownRenderer extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     ThemeData theme = Theme.of(context);
+    var settings = Provider.of<Settings>(context);
     theme = theme.copyWith(
       textTheme: theme.textTheme.copyWith(
         subtitle1: theme.textTheme.subtitle1,
@@ -120,22 +124,29 @@ class MarkdownRenderer extends StatelessWidget {
       imageBuilder: (url, title, alt) => MarkdownImage(
           url, note.parent.folderPath + p.separator,
           titel: title, altText: alt),
-      extensionSet: markdownExtensions(),
+      extensionSet: markdownExtensions(hardWrapEnabled: settings.hardWrap),
     );
 
     return view;
   }
 
-  static md.ExtensionSet markdownExtensions() {
+  static md.ExtensionSet markdownExtensions({bool hardWrapEnabled = false}) {
     // It's important to add both these inline syntaxes before the other
     // syntaxes as the LinkSyntax intefers with both of these
     var markdownExtensions = md.ExtensionSet(
       md.ExtensionSet.gitHubFlavored.blockSyntaxes,
-      [
-        WikiLinkSyntax(),
-        TaskListSyntax(),
-        ...md.ExtensionSet.gitHubFlavored.inlineSyntaxes,
-      ],
+      hardWrapEnabled
+          ? [
+              HardWrapSyntax(),
+              WikiLinkSyntax(),
+              TaskListSyntax(),
+              ...md.ExtensionSet.gitHubFlavored.inlineSyntaxes,
+            ]
+          : [
+              WikiLinkSyntax(),
+              TaskListSyntax(),
+              ...md.ExtensionSet.gitHubFlavored.inlineSyntaxes,
+            ],
     );
     return markdownExtensions;
   }


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue #505 

Added for rendering options for render soft line breaks as hard line breaks, as like as GitHub's editor.

It allowed in [CommonMark spec](https://spec.commonmark.org/0.29/#hard-line-breaks)
> A renderer may also provide an option to render soft line breaks as hard line breaks.

If enable this option.
```
hello<CR>
world
```
would be rendered to
```
hello
world
```
as same as 
```
hello<SPC><SPC><SPC><CR>
world
```
It affects only to paragraph.
