### PR TITLE
Fix changes detection #615

### DIFF
--- a/lib/core/markdown/md_yaml_doc.dart
+++ b/lib/core/markdown/md_yaml_doc.dart
@@ -43,7 +43,7 @@ class MdYamlDoc {
       other is MdYamlDoc &&
           runtimeType == other.runtimeType &&
           body == other.body &&
-          _deepEq(props, other.props);
+          _deepEq(props.unlock, other.props.unlock);
 
   @override
   String toString() {


### PR DESCRIPTION
What changed?

Notes' properties are now compared using Map interface
and not IMap. IMap is incorrectly handled by DeepCollectionEquality,
which causes equal lists (for example of tags) to be marked as unequal.

<!--
SPDX-FileCopyrightText: 2019-2021 Vishesh Handa <me@vhanda.in>
SPDX-FileCopyrightText: 2019-2021 deandreamatias <deandreamatias@gmail.com>

SPDX-License-Identifier: CC-BY-4.0
-->

## Connection with issue(s)

Resolves issue #615

## Testing and Review Notes

Create a note with tags field. Save note. Enter and exit without making changes.
