### PR TITLE
Fix assertion error in metadata screen

### DIFF
--- a/lib/core/file/file.dart
+++ b/lib/core/file/file.dart
@@ -69,6 +69,13 @@ class File {
     assert(repoPath.endsWith(p.separator));
   }
 
+  File.virtual({required this.created, DateTime? modified})
+      : filePath = '',
+        repoPath = '',
+        oid = GitHash.zero(),
+        fileLastModified = DateTime.now(),
+        modified = modified ?? created;
+
   String get fileName => p.basename(filePath);
 
   File copyFile({

--- a/lib/settings/settings_note_metadata.dart
+++ b/lib/settings/settings_note_metadata.dart
@@ -71,13 +71,9 @@ class _NoteMetadataSettingsScreenState
       parent: parent,
       fileFormat: NoteFileFormat.Markdown,
       noteType: NoteType.Unknown,
-      file: File(
-        filePath: '',
-        repoPath: '',
+      file: File.virtual(
         created: created,
         modified: modified,
-        oid: GitHash.zero(),
-        fileLastModified: DateTime.now(),
       ),
       created: created,
       modified: modified,


### PR DESCRIPTION
Reason for changes

In debug/dev mode it is impossible to enter metadata edition
screen since it results in an assertion error. The production
flavour doesn't have this problem, because asserts are removed.
The error is caused by empty repo and file paths that in the Note
constructor are inserted by the metadata screen build method. This screen
needs a note just to show effects of a user configuration.

What changed?

I added a new factory method to File in order to avoid assertion
checks.

<!--
SPDX-FileCopyrightText: 2019-2021 Vishesh Handa <me@vhanda.in>
SPDX-FileCopyrightText: 2019-2021 deandreamatias <deandreamatias@gmail.com>

SPDX-License-Identifier: CC-BY-4.0
-->

## Testing and Review Notes

Try to open metadata settings in the dev mode.
