### PR TITLE
Bugfix/exc when changing repo

### DIFF
--- a/lib/widgets/app_drawer.dart
+++ b/lib/widgets/app_drawer.dart
@@ -340,14 +340,7 @@ class RepoTile extends StatelessWidget {
       leading: icon,
       title: Text(repoManager.repoFolderName(id)),
       onTap: () async {
-        Navigator.pop(context);
-
-        var r = await repoManager.setCurrentRepo(id);
-        var route = r.isFailure ? ErrorScreen.routePath : HomeScreen.routePath;
-        var _ = Navigator.of(context).pushNamedAndRemoveUntil(
-          route,
-          (r) => true,
-        );
+        await repoManager.setCurrentRepo(id);
       },
     );
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2019-2021 Vishesh Handa <me@vhanda.in>
SPDX-FileCopyrightText: 2019-2021 deandreamatias <deandreamatias@gmail.com>

SPDX-License-Identifier: CC-BY-4.0
-->

Reason for changes

Changing a route on RepoTile tap is causing the following error:

> Looking up a deactivated widget's ancestor is unsafe.

The exception is caused by an attempt to use already defunct context.
The context has been destroyed during the repo change a line before.
Effectively, the removed lines do not do anything since the entire
app is rebuilt using GitJournalChangeNotifier and doesn't change a route
by the navigator.

What changed?

Removed lines that caused errors and had no effect.

## Testing and Review Notes

Change repository in the draw while in dev mode. Look at the console log.
