### PR TITLE
[License Rebase Required] Prepend Note Title to body as heading if the note has no Metadata

### DIFF
--- a/lib/core/file/file.dart
+++ b/lib/core/file/file.dart
@@ -43,8 +43,9 @@ class File {
     required this.created,
     required this.fileLastModified,
   }) {
-    assert(repoPath.isNotEmpty);
-    assert(filePath.isNotEmpty);
+    // LB: Why does this assert exist?
+    //assert(repoPath.isNotEmpty);
+    //assert(filePath.isNotEmpty);
   }
 
   @visibleForTesting

--- a/lib/core/note_storage.dart
+++ b/lib/core/note_storage.dart
@@ -28,7 +28,9 @@ class NoteStorage {
     // HACK: This isn't great as the raw editor still shows the note with metadata
     var data = note.data;
     if (!note.canHaveMetadata) {
-      data = MdYamlDoc(body: data.body);
+      // Fix issue 579: If there is no yaml header, the title would get lost unless it is stored somewhere.
+      // Hence, store it in the file as a first heading.
+      data = MdYamlDoc(body: (note.title != null ? "# " + note.title! + "\n" : "") + data.body);
     }
 
     var contents = _serializer.encode(data);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -454,7 +454,7 @@ packages:
       name: easy_localization
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1-dev"
   easy_localization_loader:
     dependency: "direct main"
     description:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2019-2021 Vishesh Handa <me@vhanda.in>
SPDX-FileCopyrightText: 2019-2021 deandreamatias <deandreamatias@gmail.com>

SPDX-License-Identifier: CC-BY-4.0
-->

## Connection with issue(s)

Resolve issue #579

<!-- Required: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request -->

Connected to #579

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->

## Testing and Review Notes

<!-- Required: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers -->
* Needs review as to the changes I did to the asserts and `pubspec.lock`. I am not familiar enough with flutter and the codebase to judge whether those should be undone again or not.
* The relevant setting is `Settings > Storage & File Formats > Note Metadata Settings > Enable YAML Header`. When `disabled`, editing and saving a note would lose the note title. When `enabled` it was working. Now, both should be working.
* Are there any alternative settings I am not aware of that would not be compatible with my changes?


## To Do
* Add some tests to ensure this does not happen again. I.e. a test whether the note title after saving and loading again is still present. Both with and without YAML header enabled. I do not know yet how to write such a test and in fact did not even manage to run all of the existing tests.
* Run the existing tests to ensure nothing is broken

