### PR TITLE
Created/modified timestamp format, and millisecond precision timestamps

### DIFF
--- a/assets/langs/en.yaml
+++ b/assets/langs/en.yaml
@@ -132,7 +132,13 @@ settings:
     text: Every note has some metadata which is stored in a YAML Header as follows -
     enableHeader: Enable YAML Header
     modified: Modified Field
+    modifiedFormat: Modified Format
     created: Created Field
+    createdFormat: Created Format
+    dateFormat:
+      iso8601: ISO 8601
+      none: None
+      unixTimestamp: Unix Timestamp
     tags: Tags Field
     example:
       title: Example Title

--- a/assets/langs/en.yaml
+++ b/assets/langs/en.yaml
@@ -131,6 +131,10 @@ settings:
     subtitle: Configure how the Note Metadata is saved
     text: Every note has some metadata which is stored in a YAML Header as follows -
     enableHeader: Enable YAML Header
+    unixTimestampMagnitude: Unix Timestamp Magnitude
+    unixTimestampDateMagnitude:
+      seconds: Seconds
+      milliseconds: Milliseconds
     modified: Modified Field
     modifiedFormat: Modified Format
     created: Created Field

--- a/lib/core/folder/notes_folder_config.dart
+++ b/lib/core/folder/notes_folder_config.dart
@@ -9,6 +9,7 @@ import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:gitjournal/core/folder/sorting_mode.dart';
+import 'package:gitjournal/core/markdown/md_yaml_note_serializer.dart';
 import 'package:gitjournal/core/notes/note.dart';
 import 'package:gitjournal/editors/common_types.dart';
 import 'package:gitjournal/folder_views/standard_view.dart';
@@ -40,7 +41,9 @@ class NotesFolderConfig extends ChangeNotifier with SettingsSharedPref {
   var yamlHeaderEnabled = true;
 
   var yamlModifiedKey = "modified";
+  var yamlModifiedFormat = NoteSerializationDateFormat.Default;
   var yamlCreatedKey = "created";
+  var yamlCreatedFormat = NoteSerializationDateFormat.Default;
   var yamlTagsKey = "tags";
   var yamlEditorTypeKey = "type";
   var titleSettings = SettingsTitle.Default;
@@ -61,7 +64,11 @@ class NotesFolderConfig extends ChangeNotifier with SettingsSharedPref {
         getString("journalNoteFileNameFormat"));
 
     yamlModifiedKey = getString("yamlModifiedKey") ?? yamlModifiedKey;
+    yamlModifiedFormat = NoteSerializationDateFormat.fromInternalString(
+        getString("yamlModifiedFormat"));
     yamlCreatedKey = getString("yamlCreatedKey") ?? yamlCreatedKey;
+    yamlCreatedFormat = NoteSerializationDateFormat.fromInternalString(
+        getString("yamlCreatedFormat"));
     yamlTagsKey = getString("yamlTagsKey") ?? yamlTagsKey;
     yamlEditorTypeKey = getString("yamlEditorTypeKey") ?? yamlEditorTypeKey;
 
@@ -119,7 +126,11 @@ class NotesFolderConfig extends ChangeNotifier with SettingsSharedPref {
     await setBool(
         "yamlHeaderEnabled", yamlHeaderEnabled, def.yamlHeaderEnabled);
     await setString("yamlModifiedKey", yamlModifiedKey, def.yamlModifiedKey);
+    await setString("yamlModifiedFormat", yamlModifiedFormat.toInternalString(),
+        def.yamlModifiedFormat.toInternalString());
     await setString("yamlCreatedKey", yamlCreatedKey, def.yamlCreatedKey);
+    await setString("yamlCreatedFormat", yamlCreatedFormat.toInternalString(),
+        def.yamlCreatedFormat.toInternalString());
     await setString("yamlTagsKey", yamlTagsKey, def.yamlTagsKey);
     await setString(
         "yamlEditorTypeKey", yamlEditorTypeKey, def.yamlEditorTypeKey);

--- a/lib/core/folder/notes_folder_config.dart
+++ b/lib/core/folder/notes_folder_config.dart
@@ -40,6 +40,8 @@ class NotesFolderConfig extends ChangeNotifier with SettingsSharedPref {
 
   var yamlHeaderEnabled = true;
 
+  var yamlUnixTimestampMagnitude =
+      NoteSerializationUnixTimestampMagnitude.Default;
   var yamlModifiedKey = "modified";
   var yamlModifiedFormat = NoteSerializationDateFormat.Default;
   var yamlCreatedKey = "created";
@@ -63,6 +65,9 @@ class NotesFolderConfig extends ChangeNotifier with SettingsSharedPref {
     journalFileNameFormat = NoteFileNameFormat.fromInternalString(
         getString("journalNoteFileNameFormat"));
 
+    yamlUnixTimestampMagnitude =
+        NoteSerializationUnixTimestampMagnitude.fromInternalString(
+            getString("yamlUnixTimestampMagnitude"));
     yamlModifiedKey = getString("yamlModifiedKey") ?? yamlModifiedKey;
     yamlModifiedFormat = NoteSerializationDateFormat.fromInternalString(
         getString("yamlModifiedFormat"));
@@ -125,6 +130,10 @@ class NotesFolderConfig extends ChangeNotifier with SettingsSharedPref {
 
     await setBool(
         "yamlHeaderEnabled", yamlHeaderEnabled, def.yamlHeaderEnabled);
+    await setString(
+        "yamlUnixTimestampMagnitude",
+        yamlUnixTimestampMagnitude.toInternalString(),
+        def.yamlUnixTimestampMagnitude.toInternalString());
     await setString("yamlModifiedKey", yamlModifiedKey, def.yamlModifiedKey);
     await setString("yamlModifiedFormat", yamlModifiedFormat.toInternalString(),
         def.yamlModifiedFormat.toInternalString());

--- a/lib/core/markdown/md_yaml_note_serializer.dart
+++ b/lib/core/markdown/md_yaml_note_serializer.dart
@@ -34,7 +34,7 @@ abstract class NoteSerializerInterface {
 
 var emojiParser = EmojiParser();
 
-enum DateFormat {
+enum NoteSerializationDateFormat {
   Iso8601,
   UnixTimeStamp,
   None,
@@ -52,8 +52,8 @@ class NoteSerializationSettings {
 
   SettingsTitle titleSettings = SettingsTitle.Default;
 
-  var modifiedFormat = DateFormat.Iso8601;
-  var createdFormat = DateFormat.Iso8601;
+  var modifiedFormat = NoteSerializationDateFormat.Iso8601;
+  var createdFormat = NoteSerializationDateFormat.Iso8601;
 
   var emojify = false;
 
@@ -118,28 +118,28 @@ class NoteSerializationSettings {
     return s;
   }
 
-  static pb.DateFormat _protoDateFormat(DateFormat fmt) {
+  static pb.DateFormat _protoDateFormat(NoteSerializationDateFormat fmt) {
     switch (fmt) {
-      case DateFormat.None:
+      case NoteSerializationDateFormat.None:
         return pb.DateFormat.None;
-      case DateFormat.Iso8601:
+      case NoteSerializationDateFormat.Iso8601:
         return pb.DateFormat.Iso8601;
-      case DateFormat.UnixTimeStamp:
+      case NoteSerializationDateFormat.UnixTimeStamp:
         return pb.DateFormat.UnixTimeStamp;
     }
   }
 
-  static DateFormat _fromProtoDateFormat(pb.DateFormat fmt) {
+  static NoteSerializationDateFormat _fromProtoDateFormat(pb.DateFormat fmt) {
     switch (fmt) {
       case pb.DateFormat.None:
-        return DateFormat.None;
+        return NoteSerializationDateFormat.None;
       case pb.DateFormat.Iso8601:
-        return DateFormat.Iso8601;
+        return NoteSerializationDateFormat.Iso8601;
       case pb.DateFormat.UnixTimeStamp:
-        return DateFormat.UnixTimeStamp;
+        return NoteSerializationDateFormat.UnixTimeStamp;
     }
 
-    return DateFormat.None;
+    return NoteSerializationDateFormat.None;
   }
 
   @override
@@ -187,25 +187,25 @@ class NoteSerializer implements NoteSerializerInterface {
     dynamic _;
 
     switch (settings.createdFormat) {
-      case DateFormat.Iso8601:
+      case NoteSerializationDateFormat.Iso8601:
         props[settings.createdKey] = toIso8601WithTimezone(note.created);
         break;
-      case DateFormat.UnixTimeStamp:
+      case NoteSerializationDateFormat.UnixTimeStamp:
         props[settings.createdKey] = toUnixTimeStamp(note.created);
         break;
-      case DateFormat.None:
+      case NoteSerializationDateFormat.None:
         _ = props.remove(settings.createdKey);
         break;
     }
 
     switch (settings.modifiedFormat) {
-      case DateFormat.Iso8601:
+      case NoteSerializationDateFormat.Iso8601:
         props[settings.modifiedKey] = toIso8601WithTimezone(note.modified);
         break;
-      case DateFormat.UnixTimeStamp:
+      case NoteSerializationDateFormat.UnixTimeStamp:
         props[settings.modifiedKey] = toUnixTimeStamp(note.modified);
         break;
-      case DateFormat.None:
+      case NoteSerializationDateFormat.None:
         _ = props.remove(settings.modifiedKey);
         break;
     }
@@ -302,10 +302,10 @@ class NoteSerializer implements NoteSerializerInterface {
       if (val != null) {
         if (val is int) {
           modified = parseUnixTimeStamp(val);
-          settings.modifiedFormat = DateFormat.UnixTimeStamp;
+          settings.modifiedFormat = NoteSerializationDateFormat.UnixTimeStamp;
         } else {
           modified = parseDateTime(val.toString());
-          settings.modifiedFormat = DateFormat.Iso8601;
+          settings.modifiedFormat = NoteSerializationDateFormat.Iso8601;
         }
         settings.modifiedKey = possibleKey;
 
@@ -314,7 +314,7 @@ class NoteSerializer implements NoteSerializerInterface {
       }
     }
     if (modified == null) {
-      settings.modifiedFormat = DateFormat.None;
+      settings.modifiedFormat = NoteSerializationDateFormat.None;
     }
 
     var body = settings.emojify ? emojiParser.emojify(data.body) : data.body;
@@ -325,10 +325,10 @@ class NoteSerializer implements NoteSerializerInterface {
       if (val != null) {
         if (val is int) {
           created = parseUnixTimeStamp(val);
-          settings.createdFormat = DateFormat.UnixTimeStamp;
+          settings.createdFormat = NoteSerializationDateFormat.UnixTimeStamp;
         } else {
           created = parseDateTime(val.toString());
-          settings.createdFormat = DateFormat.Iso8601;
+          settings.createdFormat = NoteSerializationDateFormat.Iso8601;
         }
         settings.createdKey = possibleKey;
 
@@ -337,7 +337,7 @@ class NoteSerializer implements NoteSerializerInterface {
       }
     }
     if (created == null) {
-      settings.createdFormat = DateFormat.None;
+      settings.createdFormat = NoteSerializationDateFormat.None;
     }
 
     //

--- a/lib/generated/core.pb.dart
+++ b/lib/generated/core.pb.dart
@@ -1009,6 +1009,16 @@ class NoteSerializationSettings extends $pb.GeneratedMessage {
             ? ''
             : 'titleSettings',
         protoName: 'titleSettings')
+    ..e<UnixTimestampMagnitude>(
+        12,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'unixTimestampMagnitude',
+        $pb.PbFieldType.OE,
+        protoName: 'unixTimestampMagnitude',
+        defaultOrMaker: UnixTimestampMagnitude.Seconds,
+        valueOf: UnixTimestampMagnitude.valueOf,
+        enumValues: UnixTimestampMagnitude.values)
     ..hasRequiredFields = false;
 
   NoteSerializationSettings._() : super();
@@ -1024,6 +1034,7 @@ class NoteSerializationSettings extends $pb.GeneratedMessage {
     DateFormat? modifiedFormat,
     DateFormat? createdFormat,
     $core.String? titleSettings,
+    UnixTimestampMagnitude? unixTimestampMagnitude,
   }) {
     final _result = create();
     if (modifiedKey != null) {
@@ -1058,6 +1069,9 @@ class NoteSerializationSettings extends $pb.GeneratedMessage {
     }
     if (titleSettings != null) {
       _result.titleSettings = titleSettings;
+    }
+    if (unixTimestampMagnitude != null) {
+      _result.unixTimestampMagnitude = unixTimestampMagnitude;
     }
     return _result;
   }
@@ -1221,4 +1235,16 @@ class NoteSerializationSettings extends $pb.GeneratedMessage {
   $core.bool hasTitleSettings() => $_has(10);
   @$pb.TagNumber(11)
   void clearTitleSettings() => clearField(11);
+
+  @$pb.TagNumber(12)
+  UnixTimestampMagnitude get unixTimestampMagnitude => $_getN(11);
+  @$pb.TagNumber(12)
+  set unixTimestampMagnitude(UnixTimestampMagnitude v) {
+    setField(12, v);
+  }
+
+  @$pb.TagNumber(12)
+  $core.bool hasUnixTimestampMagnitude() => $_has(11);
+  @$pb.TagNumber(12)
+  void clearUnixTimestampMagnitude() => clearField(12);
 }

--- a/lib/generated/core.pbenum.dart
+++ b/lib/generated/core.pbenum.dart
@@ -81,6 +81,31 @@ class NoteType extends $pb.ProtobufEnum {
   const NoteType._($core.int v, $core.String n) : super(v, n);
 }
 
+class UnixTimestampMagnitude extends $pb.ProtobufEnum {
+  static const UnixTimestampMagnitude Seconds = UnixTimestampMagnitude._(
+      0,
+      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
+          ? ''
+          : 'Seconds');
+  static const UnixTimestampMagnitude Milliseconds = UnixTimestampMagnitude._(
+      1,
+      const $core.bool.fromEnvironment('protobuf.omit_enum_names')
+          ? ''
+          : 'Milliseconds');
+
+  static const $core.List<UnixTimestampMagnitude> values =
+      <UnixTimestampMagnitude>[
+    Seconds,
+    Milliseconds,
+  ];
+
+  static final $core.Map<$core.int, UnixTimestampMagnitude> _byValue =
+      $pb.ProtobufEnum.initByValue(values);
+  static UnixTimestampMagnitude? valueOf($core.int value) => _byValue[value];
+
+  const UnixTimestampMagnitude._($core.int v, $core.String n) : super(v, n);
+}
+
 class DateFormat extends $pb.ProtobufEnum {
   static const DateFormat Iso8601 = DateFormat._(
       0,

--- a/lib/generated/core.pbjson.dart
+++ b/lib/generated/core.pbjson.dart
@@ -40,6 +40,19 @@ const NoteType$json = const {
 /// Descriptor for `NoteType`. Decode as a `google.protobuf.EnumDescriptorProto`.
 final $typed_data.Uint8List noteTypeDescriptor = $convert.base64Decode(
     'CghOb3RlVHlwZRILCgdVbmtub3duEAASDQoJQ2hlY2tsaXN0EAESCwoHSm91cm5hbBACEgcKA09yZxAD');
+@$core.Deprecated('Use unixTimestampMagnitudeDescriptor instead')
+const UnixTimestampMagnitude$json = const {
+  '1': 'UnixTimestampMagnitude',
+  '2': const [
+    const {'1': 'Seconds', '2': 0},
+    const {'1': 'Milliseconds', '2': 1},
+  ],
+};
+
+/// Descriptor for `UnixTimestampMagnitude`. Decode as a `google.protobuf.EnumDescriptorProto`.
+final $typed_data.Uint8List unixTimestampMagnitudeDescriptor =
+    $convert.base64Decode(
+        'ChZVbml4VGltZXN0YW1wTWFnbml0dWRlEgsKB1NlY29uZHMQABIQCgxNaWxsaXNlY29uZHMQAQ==');
 @$core.Deprecated('Use dateFormatDescriptor instead')
 const DateFormat$json = const {
   '1': 'DateFormat',
@@ -354,10 +367,18 @@ const NoteSerializationSettings$json = const {
       '5': 9,
       '10': 'titleSettings'
     },
+    const {
+      '1': 'unixTimestampMagnitude',
+      '3': 12,
+      '4': 1,
+      '5': 14,
+      '6': '.gitjournal.UnixTimestampMagnitude',
+      '10': 'unixTimestampMagnitude'
+    },
   ],
 };
 
 /// Descriptor for `NoteSerializationSettings`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List noteSerializationSettingsDescriptor =
     $convert.base64Decode(
-        'ChlOb3RlU2VyaWFsaXphdGlvblNldHRpbmdzEiAKC21vZGlmaWVkS2V5GAEgASgJUgttb2RpZmllZEtleRIeCgpjcmVhdGVkS2V5GAIgASgJUgpjcmVhdGVkS2V5EhoKCHRpdGxlS2V5GAMgASgJUgh0aXRsZUtleRIYCgd0eXBlS2V5GAQgASgJUgd0eXBlS2V5EhgKB3RhZ3NLZXkYBSABKAlSB3RhZ3NLZXkSIgoMdGFnc0luU3RyaW5nGAYgASgIUgx0YWdzSW5TdHJpbmcSIgoMdGFnc0hhdmVIYXNoGAcgASgIUgx0YWdzSGF2ZUhhc2gSGAoHZW1vamlmeRgIIAEoCFIHZW1vamlmeRI+Cg5tb2RpZmllZEZvcm1hdBgJIAEoDjIWLmdpdGpvdXJuYWwuRGF0ZUZvcm1hdFIObW9kaWZpZWRGb3JtYXQSPAoNY3JlYXRlZEZvcm1hdBgKIAEoDjIWLmdpdGpvdXJuYWwuRGF0ZUZvcm1hdFINY3JlYXRlZEZvcm1hdBIkCg10aXRsZVNldHRpbmdzGAsgASgJUg10aXRsZVNldHRpbmdz');
+        'ChlOb3RlU2VyaWFsaXphdGlvblNldHRpbmdzEiAKC21vZGlmaWVkS2V5GAEgASgJUgttb2RpZmllZEtleRIeCgpjcmVhdGVkS2V5GAIgASgJUgpjcmVhdGVkS2V5EhoKCHRpdGxlS2V5GAMgASgJUgh0aXRsZUtleRIYCgd0eXBlS2V5GAQgASgJUgd0eXBlS2V5EhgKB3RhZ3NLZXkYBSABKAlSB3RhZ3NLZXkSIgoMdGFnc0luU3RyaW5nGAYgASgIUgx0YWdzSW5TdHJpbmcSIgoMdGFnc0hhdmVIYXNoGAcgASgIUgx0YWdzSGF2ZUhhc2gSGAoHZW1vamlmeRgIIAEoCFIHZW1vamlmeRI+Cg5tb2RpZmllZEZvcm1hdBgJIAEoDjIWLmdpdGpvdXJuYWwuRGF0ZUZvcm1hdFIObW9kaWZpZWRGb3JtYXQSPAoNY3JlYXRlZEZvcm1hdBgKIAEoDjIWLmdpdGpvdXJuYWwuRGF0ZUZvcm1hdFINY3JlYXRlZEZvcm1hdBIkCg10aXRsZVNldHRpbmdzGAsgASgJUg10aXRsZVNldHRpbmdzEloKFnVuaXhUaW1lc3RhbXBNYWduaXR1ZGUYDCABKA4yIi5naXRqb3VybmFsLlVuaXhUaW1lc3RhbXBNYWduaXR1ZGVSFnVuaXhUaW1lc3RhbXBNYWduaXR1ZGU=');

--- a/lib/generated/locale_keys.g.dart
+++ b/lib/generated/locale_keys.g.dart
@@ -216,7 +216,19 @@ abstract class LocaleKeys {
       'settings.noteMetaData.enableHeader';
   static const settings_noteMetaData_modified =
       'settings.noteMetaData.modified';
+  static const settings_noteMetaData_modifiedFormat =
+      'settings.noteMetaData.modifiedFormat';
   static const settings_noteMetaData_created = 'settings.noteMetaData.created';
+  static const settings_noteMetaData_createdFormat =
+      'settings.noteMetaData.createdFormat';
+  static const settings_noteMetaData_dateFormat_iso8601 =
+      'settings.noteMetaData.dateFormat.iso8601';
+  static const settings_noteMetaData_dateFormat_none =
+      'settings.noteMetaData.dateFormat.none';
+  static const settings_noteMetaData_dateFormat_unixTimestamp =
+      'settings.noteMetaData.dateFormat.unixTimestamp';
+  static const settings_noteMetaData_dateFormat =
+      'settings.noteMetaData.dateFormat';
   static const settings_noteMetaData_tags = 'settings.noteMetaData.tags';
   static const settings_noteMetaData_example_title =
       'settings.noteMetaData.example.title';

--- a/lib/generated/locale_keys.g.dart
+++ b/lib/generated/locale_keys.g.dart
@@ -214,6 +214,14 @@ abstract class LocaleKeys {
   static const settings_noteMetaData_text = 'settings.noteMetaData.text';
   static const settings_noteMetaData_enableHeader =
       'settings.noteMetaData.enableHeader';
+  static const settings_noteMetaData_unixTimestampMagnitude =
+      'settings.noteMetaData.unixTimestampMagnitude';
+  static const settings_noteMetaData_unixTimestampDateMagnitude_seconds =
+      'settings.noteMetaData.unixTimestampDateMagnitude.seconds';
+  static const settings_noteMetaData_unixTimestampDateMagnitude_milliseconds =
+      'settings.noteMetaData.unixTimestampDateMagnitude.milliseconds';
+  static const settings_noteMetaData_unixTimestampDateMagnitude =
+      'settings.noteMetaData.unixTimestampDateMagnitude';
   static const settings_noteMetaData_modified =
       'settings.noteMetaData.modified';
   static const settings_noteMetaData_modifiedFormat =

--- a/lib/settings/settings_note_metadata.dart
+++ b/lib/settings/settings_note_metadata.dart
@@ -118,6 +118,22 @@ class _NoteMetadataSettingsScreenState
           },
         ),
         ListPreference(
+            title: LocaleKeys.settings_noteMetaData_unixTimestampMagnitude.tr(),
+            options: NoteSerializationUnixTimestampMagnitude.options
+                .map((m) => m.toPublicString())
+                .toList(),
+            currentOption:
+                folderConfig.yamlUnixTimestampMagnitude.toPublicString(),
+            onChange: (String publicStr) {
+              setState(() {
+                var newVal =
+                    NoteSerializationUnixTimestampMagnitude.fromPublicString(
+                        publicStr);
+                folderConfig.yamlUnixTimestampMagnitude = newVal;
+                folderConfig.save();
+              });
+            }),
+        ListPreference(
           title: LocaleKeys.settings_noteMetaData_modified.tr(),
           options: NoteSerializer.modifiedKeyOptions,
           currentOption: folderConfig.yamlModifiedKey,

--- a/lib/settings/settings_note_metadata.dart
+++ b/lib/settings/settings_note_metadata.dart
@@ -130,12 +130,44 @@ class _NoteMetadataSettingsScreenState
           enabled: folderConfig.yamlHeaderEnabled,
         ),
         ListPreference(
+          title: LocaleKeys.settings_noteMetaData_modifiedFormat.tr(),
+          options: NoteSerializationDateFormat.options
+              .map((f) => f.toPublicString())
+              .toList(),
+          currentOption: folderConfig.yamlModifiedFormat.toPublicString(),
+          onChange: (String publicStr) {
+            setState(() {
+              var newVal =
+                  NoteSerializationDateFormat.fromPublicString(publicStr);
+              folderConfig.yamlModifiedFormat = newVal;
+              folderConfig.save();
+            });
+          },
+          enabled: folderConfig.yamlHeaderEnabled,
+        ),
+        ListPreference(
           title: LocaleKeys.settings_noteMetaData_created.tr(),
           options: NoteSerializer.createdKeyOptions,
           currentOption: folderConfig.yamlCreatedKey,
           onChange: (String newVal) {
             setState(() {
               folderConfig.yamlCreatedKey = newVal;
+              folderConfig.save();
+            });
+          },
+          enabled: folderConfig.yamlHeaderEnabled,
+        ),
+        ListPreference(
+          title: LocaleKeys.settings_noteMetaData_createdFormat.tr(),
+          options: NoteSerializationDateFormat.options
+              .map((f) => f.toPublicString())
+              .toList(),
+          currentOption: folderConfig.yamlCreatedFormat.toPublicString(),
+          onChange: (String publicStr) {
+            setState(() {
+              var newVal =
+                  NoteSerializationDateFormat.fromPublicString(publicStr);
+              folderConfig.yamlCreatedFormat = newVal;
               folderConfig.save();
             });
           },

--- a/lib/utils/datetime.dart
+++ b/lib/utils/datetime.dart
@@ -8,6 +8,7 @@ import 'dart:core';
 
 import 'package:dart_git/utils/date_time.dart';
 import 'package:fixnum/fixnum.dart' as fixnum;
+import 'package:gitjournal/core/markdown/md_yaml_note_serializer.dart';
 import 'package:intl/intl.dart';
 
 import 'package:gitjournal/generated/core.pb.dart' as pb;
@@ -74,12 +75,22 @@ DateTime? parseDateTime(String str) {
   return null;
 }
 
-DateTime parseUnixTimeStamp(int val) {
-  return DateTime.fromMillisecondsSinceEpoch(val * 1000, isUtc: true);
+DateTime parseUnixTimeStamp(int val, NoteSerializationUnixTimestampMagnitude magnitude) {
+  if (magnitude == NoteSerializationUnixTimestampMagnitude.Seconds) {
+    val *= 1000;
+  }
+  return DateTime.fromMillisecondsSinceEpoch(val, isUtc: true);
 }
 
-int toUnixTimeStamp(DateTime dt) {
-  return dt.toUtc().millisecondsSinceEpoch ~/ 1000;
+int toUnixTimeStamp(DateTime dt, NoteSerializationUnixTimestampMagnitude magnitude) {
+  var timestamp = dt.toUtc();
+  switch (magnitude) {
+    case NoteSerializationUnixTimestampMagnitude.Milliseconds:
+      return timestamp.millisecondsSinceEpoch;
+    case NoteSerializationUnixTimestampMagnitude.Seconds:
+    default:
+      return timestamp.millisecondsSinceEpoch ~/ 1000;
+  }
 }
 
 extension ProtoBuf on DateTime {

--- a/protos/core.proto
+++ b/protos/core.proto
@@ -78,6 +78,10 @@ message DateTimeAnyTz {
     int32 offset = 2;
 }
 
+enum UnixTimestampMagnitude {
+    Seconds = 0;
+    Milliseconds = 1;
+}
 
 enum DateFormat {
     Iso8601 = 0;
@@ -101,4 +105,6 @@ message NoteSerializationSettings {
     DateFormat createdFormat = 10;
 
     string titleSettings = 11;
+
+    UnixTimestampMagnitude unixTimestampMagnitude = 12;
 }


### PR DESCRIPTION
There are two changes in this PR:

1. Add _Created Format_ and _Modified Format_ options under _Settings_ -> _Storage & File Format_ -> _Note Metadata Settings_ which allow switching between Unix timestamps and ISO 8601 formatted dates.
2. To improve compatibility with dendronhq/dendron, add support for Unix timestamps expressed in millisecond precision. To avoid ambiguity, a new option (_Unix Timestamp Magnitude_) has been added which controls the precision of both the created and modified timestamps.

Feedback welcome, especially since:

- I'm not sure of naming here (precision seems more appropriate to timers, but magnitude and unit don't quite feel right either).
- I'm new to Flutter/Dart and have tried to follow the existing conventions.
- I'm not sure what level of test coverage this feature should have.

## Connection with issue(s)

- Resolve issue #349
- Connected to #279

## Testing and Review Notes

- Test that new notes respect the configured date/time format.
- Test that with the magnitude set to ms and the date format set to Unix timestamp, an existing `modified` timestamp in ms precision is not truncated to s precision when updating a note.
- Test that with the magnitude set to s and the date format set to Unix timestamp, an existing `modified` timestamp in s precision is not increased to ms precision when updating a note.

## Screenshots or Videos

<img width="551" alt="image" src="https://user-images.githubusercontent.com/597015/180089591-5a7627dd-c757-45ae-97c7-baddb1859c34.png">

## To Do

- [ ] Determine what test coverage is appropriate