### PR TITLE
Fix bug where saving new note can create duplicate files

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -66,3 +66,11 @@ Example launch.json:
     ]
 }
 ```
+
+### Debugging with breakpoints
+
+To use Android Studio's debugger with breakpoints:
+* Open your local repo with Android Studio.
+* Android Studio should already have a Flutter Run Configuration named "main.dart", visible at the top of the window.
+* Edit this run configuration. For "Build flavor", type "dev" and save the configuration.
+* On the top bar of Android Studio, with "main.dart" selected, click the debug button (it has hover text "Debug main.dart").

--- a/lib/editors/note_editor.dart
+++ b/lib/editors/note_editor.dart
@@ -40,6 +40,7 @@ import 'package:gitjournal/widgets/rename_dialog.dart';
 import 'package:path/path.dart' as p;
 import 'package:provider/provider.dart';
 import 'package:synchronized/synchronized.dart';
+import 'package:universal_io/io.dart' as io;
 
 class ShowUndoSnackbar {}
 
@@ -511,6 +512,17 @@ class NoteEditorState extends State<NoteEditor>
       if (_isNewNote && !_newNoteRenamed) {
         if (note.shouldRebuildPath) {
           Log.d("Rebuilding Note's FileName");
+
+          // It's a new note, but the file might already be saved to disk during didChangeAppLifecycleState
+          // if the user switched to another app and then returned before saving.
+          // If that's the case, deleting the existing file will avoid saving 2 files.
+          var filePath = note.fullFilePath;
+          final file = io.File(filePath);
+          if (file.existsSync()) {
+            Log.d("Deleting existing file for new note");
+            file.deleteSync();
+          }
+
           note = note.copyWithFileName(note.rebuildFileName());
           setState(() {
             _note = note;


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2019-2021 Vishesh Handa <me@vhanda.in>
SPDX-FileCopyrightText: 2019-2021 deandreamatias <deandreamatias@gmail.com>

SPDX-License-Identifier: CC-BY-4.0
-->

## Connection with issue(s)

Resolve issue #638

<!-- Required: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request -->

## Testing and Review Notes

Steps to reproduce/test:
* Tap + to create a new note. The editor appears.
* Type in a title and a note body
* Press android's home button.
* Open android's Recents screen. (Swipe up on newer phones, or the square/rectangle nav bar button on older phones)
* Find GitJournal and tap to open it back up.
* Tap the check mark (top left) to save the note.
* Notice that only 1 copy of the note is saved.

Context / what I learned
* This was happening because the note was already being saved to disk when closing the app https://github.com/GitJournal/GitJournal/blob/9a14048bf67c1cbb2eb20d55eb171fc63f587cf3/lib/editors/note_editor.dart#L242 but then it was getting saved again here (with the new filename) https://github.com/GitJournal/GitJournal/blob/9a14048bf67c1cbb2eb20d55eb171fc63f587cf3/lib/editors/note_editor.dart#L522 The call to `repo.addNote(note)` is basically running `git add .`, and it was picking up both copies of the file.
* I am doing IO operations without adding a try/catch. But the code already is running inside a try/catch with a pretty generic catch block, so any possible errors should be handled gracefully here.

<!-- Required: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers -->

## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

![Image 2022-10-16 at 1 09 32 AM](https://user-images.githubusercontent.com/4809268/196020996-48acd42b-e75c-40fa-b8e9-346e204f366d.jpg)


## To Do

<!-- Add “WIP” to the PR title if pushing up but not complete nor ready for review -->
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
