### PR TITLE
Fixed bug for single journal per day where it would open a non-journal note

### DIFF
--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -9,6 +9,7 @@ import 'package:flutter/foundation.dart' as foundation;
 import 'package:flutter/material.dart';
 import 'package:gitjournal/core/folder/notes_folder_fs.dart';
 import 'package:gitjournal/core/note_storage.dart';
+import 'package:gitjournal/core/notes/note.dart';
 import 'package:gitjournal/l10n.dart';
 import 'package:gitjournal/settings/settings.dart';
 import 'package:gitjournal/utils/result.dart';
@@ -117,7 +118,7 @@ Future<void> shareNote(Note note) async {
 Future<Note?> getTodayJournalEntry(NotesFolderFS rootFolder) async {
   var today = Date.today;
   var matches = await rootFolder.matchNotes((n) async {
-    return n.created.isAtSameDayAs(today);
+    return n.type == NoteType.Journal && n.created.isAtSameDayAs(today);
   });
 
   return matches.isNotEmpty ? matches[0] : null;


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue #895 

<!-- Required: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request -->

## Testing and Review Notes

* Set the journal setting to 'single journal entry file per day'
* Create some non-journal notes
* Press the journal entry button on the note list
* Journal entry should appear, not one of the previously created non-journal notes
