### PR TITLE
Fixed bug where the delete button inside an editor wouldn't work due …

### DIFF
--- a/lib/editors/note_editor.dart
+++ b/lib/editors/note_editor.dart
@@ -40,6 +40,7 @@ import 'package:gitjournal/widgets/rename_dialog.dart';
 import 'package:path/path.dart' as p;
 import 'package:provider/provider.dart';
 import 'package:synchronized/synchronized.dart';
+import 'package:dart_git/plumbing/git_hash.dart';
 
 class ShowUndoSnackbar {}
 
@@ -131,6 +132,7 @@ class NoteEditorState extends State<NoteEditor>
   bool _newNoteRenamed = false;
   late EditorType _editorType;
   MdYamlDoc _originalNoteData = MdYamlDoc();
+  GitHash? _originalNoteOid;
 
   final _rawEditorKey = GlobalKey<RawEditorState>();
   final _markdownEditorKey = GlobalKey<MarkdownEditorState>();
@@ -190,6 +192,7 @@ class NoteEditorState extends State<NoteEditor>
 
     if (widget.existingNote != null) {
       var existingNote = widget.existingNote!;
+      _originalNoteOid = existingNote.oid;
       _note = existingNote.resetOid();
       _originalNoteData = _note.data;
 
@@ -460,6 +463,10 @@ class NoteEditorState extends State<NoteEditor>
     if (shouldDelete == true) {
       if (!_isNewNote) {
         var stateContainer = context.read<GitJournalRepo>();
+        if (_originalNoteOid != null) {
+          //can't delete with blank oid, so get a note with original oid
+          note = note.copyWith(file: note.file.copyFile(oid: _originalNoteOid));
+        }
         stateContainer.removeNote(note);
       }
 


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue #897 

## Testing and Review Notes

* Open a note
* Press the delete button and confirm the deletion
* Note should be deleted, previously it would remain in the list

This was due to the note being copied into a new note with blank oid upon opening.  The delete function requires the note's file to have an oid in order to do the deletion.  The change simply remembers the original oid and if the user is doing a deletion, then gets the note again, with oid intact, and passes that to the removeNote function.
