### PR TITLE
Show date and time as header for journal entries in grid/card view

### DIFF
--- a/lib/folder_views/note_tile.dart
+++ b/lib/folder_views/note_tile.dart
@@ -12,6 +12,7 @@ import 'package:gitjournal/core/note.dart';
 import 'package:gitjournal/core/notes/note.dart';
 import 'package:gitjournal/utils/markdown.dart';
 import 'package:gitjournal/widgets/highlighted_text.dart';
+import 'package:intl/intl.dart';
 
 class NoteTile extends StatelessWidget {
   final Note note;
@@ -67,6 +68,17 @@ class NoteTile extends StatelessWidget {
               highlightTextLowerCase: searchTermLowerCase,
             ),
           if (note.title != null) const SizedBox(height: 8.0),
+          if (note.title == null && note.type == NoteType.Journal)
+            HighlightedText(
+              text: '${note.created.day} ${DateFormat('MMMM, yyyy').format(note.created)}\n${DateFormat('EEEE HH:mm').format(note.created)}',
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: textTheme.headline6!
+                  .copyWith(fontSize: textTheme.headline6!.fontSize! * 0.8),
+              highlightText: searchTerm,
+              highlightTextLowerCase: searchTermLowerCase,
+            ),
+          if (note.title == null && note.type == NoteType.Journal) const SizedBox(height: 8.0),
           Flexible(
             flex: 1,
             child: _buildBody(context, body),


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue #899

## Testing and Review Notes

* Create a journal entry (or multiples)
* Switch to grid / card view on the note list
* The journal entries should have a header element showing the date and time in the same format as when opening a journal entry.