### PR TITLE
Fixed bug where commit message for move had the source path for the d…

### DIFF
--- a/lib/core/folder/notes_folder_fs.dart
+++ b/lib/core/folder/notes_folder_fs.dart
@@ -705,7 +705,7 @@ class NotesFolderFS with NotesFolderNotifier implements NotesFolder {
     }
 
     note.parent.remove(note);
-    note = note.copyWith(parent: destFolder);
+    note = note.copyWith(parent: destFolder, filePath: "${destFolder.folderPath}/${note.fileName}");
     note.parent.add(note);
 
     return Result(note);


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue #660 

## Testing and Review Notes

* Select a note on the notes list
* Move it to another folder
* Commit message should be "Moved Note <source folder>/<note name> -> <dest folder>/<note name>"

The bug was caused by the note being copied with a call to note.copyWith where the parent parameter was passed the destination folder, but the copied file path was still the source note's file path.  It now passes in the destination file path to the copyWith call.
