### PR TITLE
WIP Title Fix and Speedup

### DIFF
--- a/lib/core/note_storage.dart
+++ b/lib/core/note_storage.dart
@@ -28,7 +28,9 @@ class NoteStorage {
     // HACK: This isn't great as the raw editor still shows the note with metadata
     var data = note.data;
     if (!note.canHaveMetadata) {
-      data = MdYamlDoc(body: data.body);
+      // Fix issue 579: If there is no yaml header, the title would get lost unless it is stored somewhere.
+      // Hence, store it in the file as a first heading.
+      data = MdYamlDoc(body: (note.title != null ? "# " + note.title! + "\n" : "") + data.body);
     }
 
     var contents = _serializer.encode(data);

--- a/lib/repository_manager.dart
+++ b/lib/repository_manager.dart
@@ -37,7 +37,7 @@ class RepositoryManager with ChangeNotifier {
   Object? get currentRepoError => _repoError;
 
   Future<GitJournalRepo?> buildActiveRepository({
-    bool loadFromCache = true,
+    bool loadFromCache = false, // LB: `false` seems to shave 2 seconds off startup.
     bool syncOnBoot = true,
   }) async {
     var repoCacheDir = p.join(cacheDir, currentId);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -309,9 +309,9 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: HEAD
-      resolved-ref: dff20f47d1ca1e133ced325a3b79c9a08d516d80
-      url: "https://github.com/GitJournal/dart-git.git"
+      ref: "4b087a6d36369e1189027995f69a83daff9ab3e3"
+      resolved-ref: "4b087a6d36369e1189027995f69a83daff9ab3e3"
+      url: "https://github.com/lucidBrot/dart-git.git"
     source: git
     version: "0.0.2"
   dart_style:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -309,9 +309,9 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "4b087a6d36369e1189027995f69a83daff9ab3e3"
-      resolved-ref: "4b087a6d36369e1189027995f69a83daff9ab3e3"
-      url: "https://github.com/lucidBrot/dart-git.git"
+      ref: HEAD
+      resolved-ref: "9769fa50cd82d0d79a930427e13fcb95dcd35593"
+      url: "https://github.com/GitJournal/dart-git.git"
     source: git
     version: "0.0.2"
   dart_style:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,10 @@ dependencies:
   cryptography: ^2.0.5
   dart_date: ^1.1.1
   dart_git:
-    git: https://github.com/GitJournal/dart-git.git
+    git:
+      # TODO: revert this to `git: https://github.com/GitJournal/dart-git.git` once the dart-git PR is merged.
+      url: https://github.com/lucidBrot/dart-git.git
+      ref: 4b087a6d36369e1189027995f69a83daff9ab3e3
   device_info_plus: ^9.1.1
   dio: ^4.0.6
   dio_smart_retry: ^1.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,10 +23,7 @@ dependencies:
   cryptography: ^2.0.5
   dart_date: ^1.1.1
   dart_git:
-    git:
-      # TODO: revert this to `git: https://github.com/GitJournal/dart-git.git` once the dart-git PR is merged.
-      url: https://github.com/lucidBrot/dart-git.git
-      ref: 4b087a6d36369e1189027995f69a83daff9ab3e3
+    git: https://github.com/GitJournal/dart-git.git
   device_info_plus: ^9.1.1
   dio: ^4.0.6
   dio_smart_retry: ^1.2.0


### PR DESCRIPTION
The change to dart-git and the disabling of caching severely improve the startup speed of the app, at least on android when using the sdcard storage.

I am also including the change my 2022 PR [here](https://github.com/GitJournal/GitJournal/pull/625) tried to introduce.
All of these changes are now relative to the current master branch.

## Connection with issues

Resolve issue #919
Resolve issue #579 
Resolve issue #891
Resolve issue #595 
Replaces PR #625


## Testing, Review Notes, To Do

- [x] Before merging, a change should be done the pubspec.yaml dependency to point to a version of dart-git that uses https://github.com/GitJournal/dart-git/pull/13 but from the GitJournal/dart-git repo instead of from my fork.

- [ ] It *is* a lot faster now. Correctness of the dart-git changes must still be tested but I'm confident.

- [ ] Inputs on how valid it is to disable caching are appreciated!