### PR TITLE
feat: add rtl language support

### DIFF
--- a/lib/editors/autocompletion_widget.dart
+++ b/lib/editors/autocompletion_widget.dart
@@ -7,6 +7,7 @@
 import 'package:flutter/material.dart';
 import 'package:gitjournal/editors/common.dart';
 import 'package:gitjournal/logger/logger.dart';
+import 'package:gitjournal/utils/rtl.dart';
 import 'package:time/time.dart';
 
 class AutoCompletionWidget extends StatefulWidget {
@@ -95,7 +96,7 @@ class _AutoCompletionWidgetState extends State<AutoCompletionWidget> {
     // print("render Box: ${renderBox.size}");
 
     TextPainter painter = TextPainter(
-      textDirection: TextDirection.ltr,
+      textDirection: detectTextDirection(newText),
       text: TextSpan(
         style: widget.textFieldStyle,
         text: newText,

--- a/lib/editors/checklist_editor.dart
+++ b/lib/editors/checklist_editor.dart
@@ -15,6 +15,7 @@ import 'package:gitjournal/editors/common.dart';
 import 'package:gitjournal/editors/note_title_editor.dart';
 import 'package:gitjournal/editors/utils/disposable_change_notifier.dart';
 import 'package:gitjournal/l10n.dart';
+import 'package:gitjournal/utils/rtl.dart';
 import 'package:gitjournal/utils/utils.dart';
 import 'package:time/time.dart';
 
@@ -396,19 +397,27 @@ class _ChecklistItemTileState extends State<ChecklistItemTile> {
       );
     }
 
-    var editor = TextField(
-      autofocus: widget.autofocus,
-      focusNode: widget.focusNode,
-      keyboardType: TextInputType.text,
-      maxLines: null,
-      style: style,
-      textCapitalization: TextCapitalization.sentences,
-      controller: _textController,
-      decoration: const InputDecoration(
-        border: InputBorder.none,
-        isDense: true,
-      ),
-      onEditingComplete: widget.itemFinished,
+    var editor = ValueListenableBuilder<TextEditingValue>(
+      valueListenable: _textController,
+      builder: (context, value, _) {
+        var direction = detectTextDirection(value.text);
+        return TextField(
+          autofocus: widget.autofocus,
+          focusNode: widget.focusNode,
+          keyboardType: TextInputType.text,
+          maxLines: null,
+          style: style,
+          textCapitalization: TextCapitalization.sentences,
+          controller: _textController,
+          decoration: const InputDecoration(
+            border: InputBorder.none,
+            isDense: true,
+          ),
+          onEditingComplete: widget.itemFinished,
+          textDirection: direction,
+          textAlign: TextAlign.start,
+        );
+      },
     );
 
     return ListTile(

--- a/lib/editors/common.dart
+++ b/lib/editors/common.dart
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import 'dart:ui' as ui;
-
 import 'package:flutter/material.dart';
 
 import 'package:function_types/function_types.dart';
@@ -125,11 +123,12 @@ class EditorAppBar extends StatelessWidget implements PreferredSizeWidget {
   }
 }
 
-Size textSize(String text, TextStyle style) {
+Size textSize(String text, TextStyle style,
+    {TextDirection textDirection = TextDirection.ltr}) {
   final TextPainter textPainter = TextPainter(
       text: TextSpan(text: text, style: style),
       maxLines: 1,
-      textDirection: ui.TextDirection.ltr)
+      textDirection: textDirection)
     ..layout(minWidth: 0, maxWidth: double.infinity);
   return textPainter.size;
 }

--- a/lib/editors/note_body_editor.dart
+++ b/lib/editors/note_body_editor.dart
@@ -6,6 +6,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:gitjournal/l10n.dart';
+import 'package:gitjournal/utils/rtl.dart';
 
 class NoteBodyEditor extends StatelessWidget {
   final TextEditingController textController;
@@ -21,25 +22,33 @@ class NoteBodyEditor extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var theme = Theme.of(context);
+    return ValueListenableBuilder<TextEditingValue>(
+      valueListenable: textController,
+      builder: (context, value, _) {
+        var theme = Theme.of(context);
+        var direction = detectTextDirection(value.text);
 
-    return TextField(
-      autofocus: autofocus,
-      keyboardType: TextInputType.multiline,
-      maxLines: null,
-      style: textStyle(context),
-      decoration: InputDecoration(
-        hintText: context.loc.editorsCommonDefaultBodyHint,
-        border: InputBorder.none,
-        fillColor: theme.scaffoldBackgroundColor,
-        hoverColor: theme.scaffoldBackgroundColor,
-        contentPadding: const EdgeInsets.all(0.0),
-        isDense: true,
-      ),
-      controller: textController,
-      textCapitalization: TextCapitalization.sentences,
-      scrollPadding: const EdgeInsets.all(0.0),
-      onChanged: (_) => onChanged(),
+        return TextField(
+          autofocus: autofocus,
+          keyboardType: TextInputType.multiline,
+          maxLines: null,
+          style: textStyle(context),
+          decoration: InputDecoration(
+            hintText: context.loc.editorsCommonDefaultBodyHint,
+            border: InputBorder.none,
+            fillColor: theme.scaffoldBackgroundColor,
+            hoverColor: theme.scaffoldBackgroundColor,
+            contentPadding: const EdgeInsets.all(0.0),
+            isDense: true,
+          ),
+          controller: textController,
+          textCapitalization: TextCapitalization.sentences,
+          scrollPadding: const EdgeInsets.all(0.0),
+          onChanged: (_) => onChanged(),
+          textDirection: direction,
+          textAlign: TextAlign.start,
+        );
+      },
     );
   }
 

--- a/lib/editors/note_title_editor.dart
+++ b/lib/editors/note_title_editor.dart
@@ -6,6 +6,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:gitjournal/l10n.dart';
+import 'package:gitjournal/utils/rtl.dart';
 
 class NoteTitleEditor extends StatelessWidget {
   final TextEditingController textController;
@@ -15,23 +16,31 @@ class NoteTitleEditor extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var theme = Theme.of(context);
-    var style = theme.textTheme.titleLarge;
+    return ValueListenableBuilder<TextEditingValue>(
+      valueListenable: textController,
+      builder: (context, value, _) {
+        var theme = Theme.of(context);
+        var style = theme.textTheme.titleLarge;
+        var direction = detectTextDirection(value.text);
 
-    return TextField(
-      keyboardType: TextInputType.text,
-      style: style,
-      decoration: InputDecoration(
-        hintText: context.loc.editorsCommonDefaultTitleHint,
-        border: InputBorder.none,
-        fillColor: theme.scaffoldBackgroundColor,
-        hoverColor: theme.scaffoldBackgroundColor,
-        contentPadding: const EdgeInsets.all(0.0),
-      ),
-      controller: textController,
-      textCapitalization: TextCapitalization.sentences,
-      maxLines: null,
-      onChanged: (_) => onChanged(),
+        return TextField(
+          keyboardType: TextInputType.text,
+          style: style,
+          decoration: InputDecoration(
+            hintText: context.loc.editorsCommonDefaultTitleHint,
+            border: InputBorder.none,
+            fillColor: theme.scaffoldBackgroundColor,
+            hoverColor: theme.scaffoldBackgroundColor,
+            contentPadding: const EdgeInsets.all(0.0),
+          ),
+          controller: textController,
+          textCapitalization: TextCapitalization.sentences,
+          maxLines: null,
+          onChanged: (_) => onChanged(),
+          textDirection: direction,
+          textAlign: TextAlign.start,
+        );
+      },
     );
   }
 }

--- a/lib/editors/org_editor.dart
+++ b/lib/editors/org_editor.dart
@@ -16,6 +16,7 @@ import 'package:gitjournal/editors/editor_scroll_view.dart';
 import 'package:gitjournal/editors/undo_redo.dart';
 import 'package:gitjournal/editors/utils/disposable_change_notifier.dart';
 import 'package:gitjournal/l10n.dart';
+import 'package:gitjournal/utils/rtl.dart';
 import 'package:gitjournal/utils/utils.dart';
 
 import 'org_text_controller.dart';
@@ -244,25 +245,33 @@ class _NoteEditor extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var theme = Theme.of(context);
+    return ValueListenableBuilder<TextEditingValue>(
+      valueListenable: textController,
+      builder: (context, value, _) {
+        var theme = Theme.of(context);
+        var direction = detectTextDirection(value.text);
 
-    return TextField(
-      autofocus: autofocus,
-      keyboardType: TextInputType.multiline,
-      maxLines: null,
-      style: textStyle(context),
-      decoration: InputDecoration(
-        hintText: context.loc.editorsCommonDefaultBodyHint,
-        border: InputBorder.none,
-        isDense: true,
-        fillColor: theme.scaffoldBackgroundColor,
-        hoverColor: theme.scaffoldBackgroundColor,
-        isCollapsed: true,
-      ),
-      controller: textController,
-      textCapitalization: TextCapitalization.sentences,
-      scrollPadding: const EdgeInsets.all(0.0),
-      onChanged: (_) => onChanged(),
+        return TextField(
+          autofocus: autofocus,
+          keyboardType: TextInputType.multiline,
+          maxLines: null,
+          style: textStyle(context),
+          decoration: InputDecoration(
+            hintText: context.loc.editorsCommonDefaultBodyHint,
+            border: InputBorder.none,
+            isDense: true,
+            fillColor: theme.scaffoldBackgroundColor,
+            hoverColor: theme.scaffoldBackgroundColor,
+            isCollapsed: true,
+          ),
+          controller: textController,
+          textCapitalization: TextCapitalization.sentences,
+          scrollPadding: const EdgeInsets.all(0.0),
+          onChanged: (_) => onChanged(),
+          textDirection: direction,
+          textAlign: TextAlign.start,
+        );
+      },
     );
   }
 }

--- a/lib/editors/raw_editor.dart
+++ b/lib/editors/raw_editor.dart
@@ -21,6 +21,7 @@ import 'package:gitjournal/l10n.dart';
 import 'package:gitjournal/logger/logger.dart';
 import 'package:gitjournal/settings/app_config.dart';
 import 'package:gitjournal/utils/utils.dart';
+import 'package:gitjournal/utils/rtl.dart';
 import 'package:gitjournal/widgets/future_builder_with_progress.dart';
 import 'package:provider/provider.dart';
 
@@ -266,50 +267,60 @@ class _NoteEditorState extends State<_NoteEditor> {
   @override
   Widget build(BuildContext context) {
     var theme = Theme.of(context);
-
-    var textField = TextField(
-      key: _textFieldKey,
-      focusNode: _focusNode,
-      autofocus: widget.autofocus,
-      keyboardType: TextInputType.multiline,
-      maxLines: null,
-      style: _NoteEditor.textStyle(context),
-      decoration: InputDecoration(
-        hintText: context.loc.editorsCommonDefaultBodyHint,
-        border: InputBorder.none,
-        isDense: true,
-        fillColor: theme.scaffoldBackgroundColor,
-        hoverColor: theme.scaffoldBackgroundColor,
-        isCollapsed: true,
-      ),
-      controller: widget.textController,
-      textCapitalization: TextCapitalization.sentences,
-      scrollPadding: const EdgeInsets.all(0.0),
-      onChanged: (_) => widget.onChanged(),
-    );
-
     var appConfig = context.watch<AppConfig>();
-    if (!appConfig.experimentalTagAutoCompletion) {
-      return textField;
-    }
 
-    final rootFolder = context.read<NotesFolderFS>();
-    final inlineTagsView = InlineTagsProvider.of(context);
+    return ValueListenableBuilder<TextEditingValue>(
+      valueListenable: widget.textController,
+      builder: (context, value, _) {
+        var direction = detectTextDirection(value.text);
 
-    futureBuilder() async {
-      var allTags = await rootFolder.getNoteTagsRecursively(inlineTagsView);
+        var textField = TextField(
+          key: _textFieldKey,
+          focusNode: _focusNode,
+          autofocus: widget.autofocus,
+          keyboardType: TextInputType.multiline,
+          maxLines: null,
+          style: _NoteEditor.textStyle(context),
+          decoration: InputDecoration(
+            hintText: context.loc.editorsCommonDefaultBodyHint,
+            border: InputBorder.none,
+            isDense: true,
+            fillColor: theme.scaffoldBackgroundColor,
+            hoverColor: theme.scaffoldBackgroundColor,
+            isCollapsed: true,
+          ),
+          controller: widget.textController,
+          textCapitalization: TextCapitalization.sentences,
+          scrollPadding: const EdgeInsets.all(0.0),
+          onChanged: (_) => widget.onChanged(),
+          textDirection: direction,
+          textAlign: TextAlign.start,
+        );
 
-      Log.d("Building autocompleter with $allTags");
-      return AutoCompletionWidget(
-        textFieldStyle: _NoteEditor.textStyle(context),
-        textFieldKey: _textFieldKey,
-        textFieldFocusNode: _focusNode,
-        textController: widget.textController,
-        tags: allTags.toList(),
-        child: textField,
-      );
-    }
+        if (!appConfig.experimentalTagAutoCompletion) {
+          return textField;
+        }
 
-    return FutureBuilderWithProgress(future: futureBuilder());
+        final rootFolder = context.read<NotesFolderFS>();
+        final inlineTagsView = InlineTagsProvider.of(context);
+
+        futureBuilder() async {
+          var allTags =
+              await rootFolder.getNoteTagsRecursively(inlineTagsView);
+
+          Log.d("Building autocompleter with $allTags");
+          return AutoCompletionWidget(
+            textFieldStyle: _NoteEditor.textStyle(context),
+            textFieldKey: _textFieldKey,
+            textFieldFocusNode: _focusNode,
+            textController: widget.textController,
+            tags: allTags.toList(),
+            child: textField,
+          );
+        }
+
+        return FutureBuilderWithProgress(future: futureBuilder());
+      },
+    );
   }
 }

--- a/lib/editors/raw_editor.dart
+++ b/lib/editors/raw_editor.dart
@@ -269,12 +269,12 @@ class _NoteEditorState extends State<_NoteEditor> {
     var theme = Theme.of(context);
     var appConfig = context.watch<AppConfig>();
 
-    return ValueListenableBuilder<TextEditingValue>(
+    final textField = ValueListenableBuilder<TextEditingValue>(
       valueListenable: widget.textController,
       builder: (context, value, _) {
         var direction = detectTextDirection(value.text);
 
-        var textField = TextField(
+        return TextField(
           key: _textFieldKey,
           focusNode: _focusNode,
           autofocus: widget.autofocus,
@@ -296,31 +296,31 @@ class _NoteEditorState extends State<_NoteEditor> {
           textDirection: direction,
           textAlign: TextAlign.start,
         );
-
-        if (!appConfig.experimentalTagAutoCompletion) {
-          return textField;
-        }
-
-        final rootFolder = context.read<NotesFolderFS>();
-        final inlineTagsView = InlineTagsProvider.of(context);
-
-        futureBuilder() async {
-          var allTags =
-              await rootFolder.getNoteTagsRecursively(inlineTagsView);
-
-          Log.d("Building autocompleter with $allTags");
-          return AutoCompletionWidget(
-            textFieldStyle: _NoteEditor.textStyle(context),
-            textFieldKey: _textFieldKey,
-            textFieldFocusNode: _focusNode,
-            textController: widget.textController,
-            tags: allTags.toList(),
-            child: textField,
-          );
-        }
-
-        return FutureBuilderWithProgress(future: futureBuilder());
       },
     );
+
+    if (!appConfig.experimentalTagAutoCompletion) {
+      return textField;
+    }
+
+    final rootFolder = context.read<NotesFolderFS>();
+    final inlineTagsView = InlineTagsProvider.of(context);
+
+    futureBuilder() async {
+      var allTags =
+          await rootFolder.getNoteTagsRecursively(inlineTagsView);
+
+      Log.d("Building autocompleter with $allTags");
+      return AutoCompletionWidget(
+        textFieldStyle: _NoteEditor.textStyle(context),
+        textFieldKey: _textFieldKey,
+        textFieldFocusNode: _focusNode,
+        textController: widget.textController,
+        tags: allTags.toList(),
+        child: textField,
+      );
+    }
+
+    return FutureBuilderWithProgress(future: futureBuilder());
   }
 }

--- a/lib/editors/search.dart
+++ b/lib/editors/search.dart
@@ -172,6 +172,7 @@ double calculateTextHeight({
   required String text,
   required TextStyle style,
   required GlobalKey editorKey,
+  TextDirection textDirection = TextDirection.ltr,
 }) {
   if (editorKey.currentContext == null) {
     return -1;
@@ -181,7 +182,7 @@ double calculateTextHeight({
   var editorWidth = renderBox.size.width;
 
   var painter = TextPainter(
-    textDirection: TextDirection.ltr,
+    textDirection: textDirection,
     text: TextSpan(style: style, text: text),
     maxLines: null,
   );

--- a/lib/folder_views/note_tile.dart
+++ b/lib/folder_views/note_tile.dart
@@ -10,6 +10,7 @@ import 'package:flutter/material.dart';
 import 'package:gitjournal/core/note.dart';
 import 'package:gitjournal/core/notes/note.dart';
 import 'package:gitjournal/utils/markdown.dart';
+import 'package:gitjournal/utils/rtl.dart';
 import 'package:gitjournal/widgets/highlighted_text.dart';
 import 'package:intl/intl.dart';
 
@@ -57,14 +58,17 @@ class NoteTile extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: <Widget>[
           if (note.title != null)
-            HighlightedText(
-              text: note.title!,
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
-              style: textTheme.titleLarge!
-                  .copyWith(fontSize: textTheme.titleLarge!.fontSize! * 0.8),
-              highlightText: searchTerm,
-              highlightTextLowerCase: searchTermLowerCase,
+            Directionality(
+              textDirection: detectTextDirection(note.title!),
+              child: HighlightedText(
+                text: note.title!,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: textTheme.titleLarge!
+                    .copyWith(fontSize: textTheme.titleLarge!.fontSize! * 0.8),
+                highlightText: searchTerm,
+                highlightTextLowerCase: searchTermLowerCase,
+              ),
             ),
           if (note.title != null) const SizedBox(height: 8.0),
           if (note.title == null && note.type == NoteType.Journal)
@@ -140,14 +144,17 @@ class NoteTile extends StatelessWidget {
   Widget _buildBody(BuildContext context, String text) {
     var textTheme = Theme.of(context).textTheme;
 
-    return HighlightedText(
-      text: text,
-      highlightText: searchTerm,
-      highlightTextLowerCase: searchTermLowerCase,
-      style: textTheme.titleMedium!
-          .copyWith(fontSize: textTheme.titleMedium!.fontSize! * 0.9),
-      overflow: TextOverflow.ellipsis,
-      maxLines: _maxLines - 1,
+    return Directionality(
+      textDirection: detectTextDirection(text),
+      child: HighlightedText(
+        text: text,
+        highlightText: searchTerm,
+        highlightTextLowerCase: searchTermLowerCase,
+        style: textTheme.titleMedium!
+            .copyWith(fontSize: textTheme.titleMedium!.fontSize! * 0.9),
+        overflow: TextOverflow.ellipsis,
+        maxLines: _maxLines - 1,
+      ),
     );
   }
 }

--- a/lib/markdown/markdown_renderer.dart
+++ b/lib/markdown/markdown_renderer.dart
@@ -18,6 +18,7 @@ import 'package:gitjournal/markdown/parsers/hardwrap.dart';
 import 'package:gitjournal/markdown/parsers/html_entities_syntax.dart';
 import 'package:gitjournal/settings/settings.dart';
 import 'package:gitjournal/utils/link_resolver.dart';
+import 'package:gitjournal/utils/rtl.dart';
 import 'package:gitjournal/utils/utils.dart';
 import 'package:gitjournal/widgets/images/markdown_image.dart';
 import 'package:markdown/markdown.dart' as md;
@@ -128,7 +129,10 @@ class MarkdownRenderer extends StatelessWidget {
       },
     );
 
-    return view;
+    return Directionality(
+      textDirection: detectTextDirection(note.body),
+      child: view,
+    );
   }
 
   static md.ExtensionSet markdownExtensions({bool hardWrapEnabled = false}) {

--- a/lib/utils/rtl.dart
+++ b/lib/utils/rtl.dart
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: 2019-2021 Vishesh Handa <me@vhanda.in>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import 'package:flutter/widgets.dart';
+
+/// Returns [TextDirection.rtl] if the first strong-directional character in
+/// [text] belongs to a known RTL script (Arabic, Hebrew, Syriac, Thaana,
+/// NKo, etc.); otherwise returns [TextDirection.ltr].
+///
+/// The scan stops at the first character whose Unicode block unambiguously
+/// indicates a writing direction, so the cost is O(1) in practice for most
+/// real-world content.
+TextDirection detectTextDirection(String text) {
+  for (final rune in text.runes) {
+    // Arabic (U+0600–U+06FF)
+    if (rune >= 0x0600 && rune <= 0x06FF) return TextDirection.rtl;
+    // Hebrew (U+0590–U+05FF)
+    if (rune >= 0x0590 && rune <= 0x05FF) return TextDirection.rtl;
+    // Syriac (U+0700–U+074F)
+    if (rune >= 0x0700 && rune <= 0x074F) return TextDirection.rtl;
+    // Arabic Supplement (U+0750–U+077F)
+    if (rune >= 0x0750 && rune <= 0x077F) return TextDirection.rtl;
+    // Thaana (U+0780–U+07BF)
+    if (rune >= 0x0780 && rune <= 0x07BF) return TextDirection.rtl;
+    // NKo (U+07C0–U+07FF)
+    if (rune >= 0x07C0 && rune <= 0x07FF) return TextDirection.rtl;
+    // Arabic Extended-A (U+08A0–U+08FF)
+    if (rune >= 0x08A0 && rune <= 0x08FF) return TextDirection.rtl;
+    // Arabic Presentation Forms-A (U+FB50–U+FDFF)
+    if (rune >= 0xFB50 && rune <= 0xFDFF) return TextDirection.rtl;
+    // Arabic Presentation Forms-B (U+FE70–U+FEFF)
+    if (rune >= 0xFE70 && rune <= 0xFEFF) return TextDirection.rtl;
+
+    // Strong LTR: Basic Latin letters (skip digits, punctuation, whitespace)
+    if ((rune >= 0x0041 && rune <= 0x005A) || // A–Z
+        (rune >= 0x0061 && rune <= 0x007A) || // a–z
+        (rune >= 0x00C0 && rune <= 0x02B8)) {
+      // Latin Extended
+      return TextDirection.ltr;
+    }
+  }
+  return TextDirection.ltr;
+}
+
+/// Returns `true` if the first strong-directional character in [text] is RTL.
+bool isRtlText(String text) =>
+    detectTextDirection(text) == TextDirection.rtl;

--- a/lib/widgets/note_viewer.dart
+++ b/lib/widgets/note_viewer.dart
@@ -34,15 +34,20 @@ class NoteViewer extends StatelessWidget {
     if (note.fileFormat == NoteFileFormat.OrgMode) {
       var handler = OrgLinkHandler(context, note);
 
-      return Org(
-        note.body,
-        onLinkTap: (link) => handler.launchUrl(link.location),
-        onLocalSectionLinkTap: (OrgTree tree) {
-          Log.d("local tree link: $tree");
-        },
-        onSectionLongPress: (OrgSection section) {
-          Log.d('local section long-press: ${section.headline.rawTitle!}');
-        },
+      return Directionality(
+        textDirection: detectTextDirection(
+          note.title?.isNotEmpty == true ? note.title! : note.body,
+        ),
+        child: Org(
+          note.body,
+          onLinkTap: (link) => handler.launchUrl(link.location),
+          onLocalSectionLinkTap: (OrgTree tree) {
+            Log.d("local tree link: $tree");
+          },
+          onSectionLongPress: (OrgSection section) {
+            Log.d('local section long-press: ${section.headline.rawTitle!}');
+          },
+        ),
       );
     }
 

--- a/lib/widgets/note_viewer.dart
+++ b/lib/widgets/note_viewer.dart
@@ -15,6 +15,7 @@ import 'package:gitjournal/editors/editor_scroll_view.dart';
 import 'package:gitjournal/folder_views/common.dart';
 import 'package:gitjournal/logger/logger.dart';
 import 'package:gitjournal/markdown/markdown_renderer.dart';
+import 'package:gitjournal/utils/rtl.dart';
 import 'package:gitjournal/widgets/notes_backlinks.dart';
 import 'package:org_flutter/org_flutter.dart';
 import 'package:provider/provider.dart';
@@ -50,7 +51,12 @@ class NoteViewer extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-          NoteTitleHeader(note.title ?? ""),
+          Directionality(
+            textDirection: detectTextDirection(
+              note.title?.isNotEmpty == true ? note.title! : note.body,
+            ),
+            child: NoteTitleHeader(note.title ?? ""),
+          ),
           Padding(
             padding: const EdgeInsets.only(top: 8.0, bottom: 8.0),
             child: MarkdownRenderer(

--- a/test/utils/rtl_test.dart
+++ b/test/utils/rtl_test.dart
@@ -61,6 +61,10 @@ void main() {
     test('Digits-only defaults to LTR', () {
       expect(detectTextDirection('12345'), TextDirection.ltr);
     });
+
+    test('Punctuation-only defaults to LTR', () {
+      expect(detectTextDirection('!@#\$%'), TextDirection.ltr);
+    });
   });
 
   group('isRtlText', () {

--- a/test/utils/rtl_test.dart
+++ b/test/utils/rtl_test.dart
@@ -1,0 +1,83 @@
+/*
+ * SPDX-FileCopyrightText: 2019-2021 Vishesh Handa <me@vhanda.in>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:gitjournal/utils/rtl.dart';
+import '../lib.dart';
+
+void main() {
+  setUpAll(gjSetupAllTests);
+
+  group('detectTextDirection', () {
+    test('Arabic text is RTL', () {
+      expect(detectTextDirection('مرحبا'), TextDirection.rtl);
+    });
+
+    test('Hebrew text is RTL', () {
+      expect(detectTextDirection('שלום'), TextDirection.rtl);
+    });
+
+    test('Latin/English text is LTR', () {
+      expect(detectTextDirection('Hello world'), TextDirection.ltr);
+    });
+
+    test('Empty string defaults to LTR', () {
+      expect(detectTextDirection(''), TextDirection.ltr);
+    });
+
+    test('Leading whitespace before RTL character is RTL', () {
+      expect(detectTextDirection('   مرحبا'), TextDirection.rtl);
+    });
+
+    test('Leading punctuation before RTL character is RTL', () {
+      expect(detectTextDirection('! مرحبا'), TextDirection.rtl);
+    });
+
+    test('Leading whitespace before Latin character is LTR', () {
+      expect(detectTextDirection('   Hello'), TextDirection.ltr);
+    });
+
+    test('Mixed string starting with RTL is RTL', () {
+      expect(detectTextDirection('مرحبا Hello'), TextDirection.rtl);
+    });
+
+    test('Mixed string starting with LTR is LTR', () {
+      expect(detectTextDirection('Hello مرحبا'), TextDirection.ltr);
+    });
+
+    test('Greek text (non-Latin non-RTL) defaults to LTR', () {
+      expect(detectTextDirection('Γειά σου'), TextDirection.ltr);
+    });
+
+    test('CJK text defaults to LTR', () {
+      expect(detectTextDirection('你好世界'), TextDirection.ltr);
+    });
+
+    test('Digits-only defaults to LTR', () {
+      expect(detectTextDirection('12345'), TextDirection.ltr);
+    });
+  });
+
+  group('isRtlText', () {
+    test('Arabic text returns true', () {
+      expect(isRtlText('مرحبا'), isTrue);
+    });
+
+    test('Hebrew text returns true', () {
+      expect(isRtlText('שלום'), isTrue);
+    });
+
+    test('English text returns false', () {
+      expect(isRtlText('Hello'), isFalse);
+    });
+
+    test('Empty string returns false', () {
+      expect(isRtlText(''), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Adds automatic right-to-left (RTL) language detection and rendering support throughout GitJournal. When a user types Arabic, Hebrew, Farsi, or any other RTL-script content, all editors and viewers automatically switch the text direction to RTL without requiring any setting change.
